### PR TITLE
Change to run build container on host network

### DIFF
--- a/src/AWS/Lambda/Runtime/Deploy.hs
+++ b/src/AWS/Lambda/Runtime/Deploy.hs
@@ -123,6 +123,7 @@ getFunctionTarget Config{..} = do
         [ "run"
         , "--mount", "type=bind,source=" <> hostProjectPath <> ",destination=" <> buildProjectPath
         , "--mount", "type=bind,source=" <> hostStackPath   <> ",destination=" <> buildStackPath
+        , "--net", "host"
         , "--rm"
         , "--stop-timeout", "0"
         , "--tty"


### PR DESCRIPTION
* Podman by default does create an isolated network,
  that by itself has internet connectivity.
* This requires `slirp4netns` to be setup on the host, which is an extra
  dependency that may be broken / misbehave.
* It offers no additional guarantees, given the fact we do not run
  servers in the build container.
* Re-using the host network is most equivalent to the permissions of the
  user starting the build.